### PR TITLE
feat(grapqhl): allow passing context_value for testing

### DIFF
--- a/aio_microservice/graphql/__init__.py
+++ b/aio_microservice/graphql/__init__.py
@@ -1,6 +1,9 @@
+from strawberry.litestar import BaseContext
+
 from aio_microservice.graphql.extension import GraphqlContext, GraphqlExtension
 
 __all__ = [
+    "BaseContext",
     "GraphqlContext",
     "GraphqlExtension",
 ]

--- a/aio_microservice/graphql/extension.py
+++ b/aio_microservice/graphql/extension.py
@@ -36,15 +36,22 @@ class _SchemaWrapper:
         self,
         query: str | None,
         variable_values: dict[str, Any] | None = None,
+        context_value: BaseContext | None = None,
         root_value: Any | None = None,  # noqa: ANN401
         operation_name: str | None = None,
         allowed_operation_types: Iterable[OperationType] | None = None,
     ) -> ExecutionResult:
-        context_value: GraphqlContext[CommonABC] = await self._service.graphql._context_getter()
+        wrapped_context_value: GraphqlContext[
+            CommonABC
+        ] = await self._service.graphql._context_getter()
+        if context_value is not None:
+            wrapped_context_value.request = context_value.request
+            wrapped_context_value.websocket = context_value.websocket
+            wrapped_context_value.response = context_value.response
         return await self._schema.execute(
             query=query,
             variable_values=variable_values,
-            context_value=context_value,
+            context_value=wrapped_context_value,
             root_value=root_value,
             operation_name=operation_name,
             allowed_operation_types=allowed_operation_types,
@@ -54,14 +61,21 @@ class _SchemaWrapper:
         self,
         query: str,
         variable_values: dict[str, Any] | None = None,
+        context_value: BaseContext | None = None,
         root_value: Any | None = None,  # noqa: ANN401
         operation_name: str | None = None,
     ) -> AsyncIterator[GraphQLExecutionResult] | GraphQLExecutionResult:
-        context_value: GraphqlContext[CommonABC] = await self._service.graphql._context_getter()
+        wrapped_context_value: GraphqlContext[
+            CommonABC
+        ] = await self._service.graphql._context_getter()
+        if context_value is not None:
+            wrapped_context_value.request = context_value.request
+            wrapped_context_value.websocket = context_value.websocket
+            wrapped_context_value.response = context_value.response
         return await self._schema.subscribe(
             query=query,
             variable_values=variable_values,
-            context_value=context_value,
+            context_value=wrapped_context_value,
             root_value=root_value,
             operation_name=operation_name,
         )

--- a/aio_microservice/http.py
+++ b/aio_microservice/http.py
@@ -1,4 +1,5 @@
-from litestar import Controller, delete, get, patch, post, put, status_codes
+from litestar import Controller, Request, delete, get, patch, post, put, status_codes
+from litestar.testing import RequestFactory
 
 from aio_microservice.core.service import HttpSettings
 from aio_microservice.core.testing import TestHttpClient
@@ -6,6 +7,8 @@ from aio_microservice.core.testing import TestHttpClient
 __all__ = [
     "Controller",
     "HttpSettings",
+    "Request",
+    "RequestFactory",
     "TestHttpClient",
     "delete",
     "get",

--- a/examples/graphql_authentication.py
+++ b/examples/graphql_authentication.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import strawberry
+
+from aio_microservice import Service, ServiceSettings
+from aio_microservice.graphql import GraphqlContext, GraphqlExtension
+
+if TYPE_CHECKING:
+    from strawberry.types import Info
+
+
+class IsAuthenticated(strawberry.BasePermission):
+    message = "User is not authenticated"
+
+    def has_permission(
+        self,
+        source: Any,  # noqa: ANN401
+        info: Info[GraphqlContext[MyService], None],
+        **kwargs: Any,  # noqa: ANN401
+    ) -> bool:
+        request = info.context.request
+        if request is None:
+            return False
+        if "authorization" not in request.headers:
+            return False
+        return "Bearer " in request.headers["authorization"]
+
+
+@strawberry.type
+class Query:
+    @strawberry.field(permission_classes=[IsAuthenticated])  # type: ignore[misc]
+    async def hello(
+        self,
+        info: Info[GraphqlContext[MyService], None],
+    ) -> str:
+        return "Hello World"
+
+
+class MyService(Service[ServiceSettings], GraphqlExtension):
+    __graphql_schema__: ClassVar = strawberry.Schema(query=Query)
+
+
+if __name__ == "__main__":
+    MyService.cli()

--- a/tests/graphql/test_graphql_test_client.py
+++ b/tests/graphql/test_graphql_test_client.py
@@ -5,7 +5,8 @@ from collections.abc import AsyncGenerator, AsyncIterator
 import strawberry
 
 from aio_microservice import Service, ServiceSettings
-from aio_microservice.graphql import GraphqlContext, GraphqlExtension
+from aio_microservice.graphql import BaseContext, GraphqlContext, GraphqlExtension
+from aio_microservice.http import RequestFactory
 
 
 async def test_graphql_test_client_query() -> None:
@@ -25,7 +26,7 @@ async def test_graphql_test_client_query() -> None:
     assert response.data == {"test": "TEST RESPONSE"}
 
 
-async def test_graphql_test_client_query_with_context() -> None:
+async def test_graphql_test_client_query_with_default_context() -> None:
     @strawberry.type
     class Query:
         @strawberry.field
@@ -48,6 +49,36 @@ async def test_graphql_test_client_query_with_context() -> None:
 
     assert response.errors is None
     assert response.data == {"test": "TEST RESPONSE"}
+
+
+async def test_graphql_test_client_query_with_custom_context() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def test(
+            self,
+            info: strawberry.types.Info[GraphqlContext[TestService], None],
+        ) -> str:
+            custom_header = info.context.request.headers["custom-header"]  # type: ignore
+            return f"{info.context.service.response}-{custom_header}"
+
+    class TestService(Service[ServiceSettings], GraphqlExtension):
+        __graphql_schema__ = strawberry.Schema(query=Query)
+
+        def __init__(self, settings: ServiceSettings | None = None) -> None:
+            super().__init__(settings=settings)
+            self.response = "TEST"
+
+    service = TestService()
+
+    query = "query { test }"
+
+    request = RequestFactory().get("/graphql", headers={"custom-header": "HEADER"})
+    context_value = BaseContext(request=request)
+    response = await service.graphql.schema.execute(query, context_value=context_value)
+
+    assert response.errors is None
+    assert response.data == {"test": "TEST-HEADER"}
 
 
 async def test_graphql_test_client_subscription() -> None:
@@ -79,7 +110,7 @@ async def test_graphql_test_client_subscription() -> None:
     assert responses[2].data == {"test": 2}
 
 
-async def test_graphql_test_client_subscription_with_context() -> None:
+async def test_graphql_test_client_subscription_with_default_context() -> None:
     @strawberry.type
     class Query:
         @strawberry.field
@@ -114,3 +145,43 @@ async def test_graphql_test_client_subscription_with_context() -> None:
     assert responses[0].data == {"test": "TEST-0"}
     assert responses[1].data == {"test": "TEST-1"}
     assert responses[2].data == {"test": "TEST-2"}
+
+
+async def test_graphql_test_client_subscription_with_custom_context() -> None:
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def dummy(self) -> bool:
+            return True
+
+    @strawberry.type
+    class Subscription:
+        @strawberry.subscription
+        async def test(
+            self,
+            info: strawberry.types.Info[GraphqlContext[TestService], None],
+            target: int = 100,
+        ) -> AsyncGenerator[str, None]:
+            custom_header = info.context.request.headers["custom-header"]  # type: ignore
+            for i in range(target):
+                yield f"{info.context.service.response_prefix}-{custom_header}-{i}"  # type: ignore
+
+    class TestService(Service[ServiceSettings], GraphqlExtension):
+        __graphql_schema__ = strawberry.Schema(query=Query, subscription=Subscription)
+
+        def __init__(self, settings: ServiceSettings | None = None) -> None:
+            super().__init__(settings=settings)
+            self.response_prefix = "TEST"
+
+    service = TestService()
+    query = "subscription { test(target: 3) }"
+    request = RequestFactory().get("/graphql", headers={"custom-header": "HEADER"})
+    context_value = BaseContext(request=request)
+    subscription = await service.graphql.schema.subscribe(query, context_value=context_value)
+
+    assert isinstance(subscription, AsyncIterator)
+    responses = [x async for x in subscription]
+    assert len(responses) == 3
+    assert responses[0].data == {"test": "TEST-HEADER-0"}
+    assert responses[1].data == {"test": "TEST-HEADER-1"}
+    assert responses[2].data == {"test": "TEST-HEADER-2"}


### PR DESCRIPTION
Problem
=======
`graphql` extension does not allow to pass a custom context value when
doing `service.schema.execute()`. One use case is to pass a request
with headers to test the authentication logic.

Solution
========
An optional context_value is now accepted as argument to
`schema.execute` and `schema.subscribe`.

Note
====
The `http` module now also exports `litestar.Request` and
`litestar.testing.RequestFactory`, useful when writing tests.